### PR TITLE
Fix zetanize command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ from requests import get
 from zetanize import zetanize
 
 html = get('https://google.com').text
-forms = zetanize(html)
+forms = zetanize.zetanize(html)
 ```
 
 Here's the output:


### PR DESCRIPTION
This PR fixes command documentation (zetanize.zetanize(html) instead of zetanize(html)).